### PR TITLE
Unicode admin problems

### DIFF
--- a/glyphs/models.py
+++ b/glyphs/models.py
@@ -11,7 +11,8 @@ class EmojiGlyph(models.Model):
 
     tags = models.ManyToManyField(
         Tag,
-        related_name='emoji_glyphs'
+        related_name='emoji_glyphs',
+        blank=True
     )
 
     def __str__(self):

--- a/macros/admin.py
+++ b/macros/admin.py
@@ -4,7 +4,7 @@ from .models import UnicodeMacro
 
 
 class UnicodeMacroAdmin(admin.ModelAdmin):
-    list_display = ('safe_text',)
+    list_display = ('safe_text', 'shortcut')
 
     class Media:
         css = {

--- a/macros/admin.py
+++ b/macros/admin.py
@@ -2,4 +2,8 @@ from django.contrib import admin
 
 from .models import UnicodeMacro
 
-admin.site.register(UnicodeMacro)
+
+class UnicodeMacroAdmin(admin.ModelAdmin):
+    list_display = ('safe_text',)
+
+admin.site.register(UnicodeMacro, UnicodeMacroAdmin)

--- a/macros/admin.py
+++ b/macros/admin.py
@@ -6,4 +6,9 @@ from .models import UnicodeMacro
 class UnicodeMacroAdmin(admin.ModelAdmin):
     list_display = ('safe_text',)
 
+    class Media:
+        css = {
+                'all': ('admin/css/macros.css',)
+        }
+
 admin.site.register(UnicodeMacro, UnicodeMacroAdmin)

--- a/macros/models.py
+++ b/macros/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.html import format_html
 
 from memecore.models import Tag
 
@@ -21,3 +22,9 @@ class UnicodeMacro(models.Model):
 
     def __str__(self):
         return self.text
+
+    def safe_text(self):
+        return format_html(
+            '<span style="font-weight: normal;">{}</span>',
+            self.text
+        )

--- a/macros/models.py
+++ b/macros/models.py
@@ -15,7 +15,8 @@ class UnicodeMacro(models.Model):
 
     tags = models.ManyToManyField(
         Tag,
-        related_name='unicode_macros'
+        related_name='unicode_macros',
+        blank=True
     )
 
     def __str__(self):

--- a/macros/models.py
+++ b/macros/models.py
@@ -25,6 +25,6 @@ class UnicodeMacro(models.Model):
 
     def safe_text(self):
         return format_html(
-            '<span style="font-weight: normal;">{}</span>',
+            '<span class="emoji-safe">{}</span>',
             self.text
         )

--- a/memecore/static/admin/css/macros.css
+++ b/memecore/static/admin/css/macros.css
@@ -1,0 +1,3 @@
+span.emoji-safe {
+    font-weight: normal;
+}


### PR DESCRIPTION
force unicode macros to display with `font-weight: normal` in admin list view because failure.
